### PR TITLE
use sentry webhook-way instead of slack-incoming

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Sentry Team and individual contributors.
+Copyright (c) 2015 BearyChat Team and individual contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,9 @@
 sentry-bearychat
 ================
 
-An extension for `Sentry <https://getsentry.com>`_ which posts notifications to a `Bearychat <https://bearychat.com>`_ channel.
+An extension for `Sentry <https://getsentry.com>`_ which posts notifications to a `BearyChat <https://bearychat.com>`_ channel.
 
 .. image:: https://cloud.githubusercontent.com/assets/2056489/4951031/44416b9c-6662-11e4-825d-b179b614828a.png
-
-Started with a fork of the Slack plugin:
-
-`https://github.com/getsentry/sentry-slack <https://github.com/getsentry/sentry-slack>`_
 
 QuickStart
 ----------
@@ -18,15 +14,15 @@ QuickStart
 
 2. Restart your sentry service
 
-3. Login your sentry website, and enter _Manage Integrations_ page of your project.
+3. Login your sentry website, and enter `Manage Integrations`_ page of your project.
 
 .. image:: https://cloud.githubusercontent.com/assets/2056489/4988175/bb5e5ef8-6999-11e4-9cef-2f6326a02ef2.png
 
-4. Tick the checkbox of _Bearychat_.
+4. Tick the checkbox of `BearyChat`_.
 
 .. image:: https://cloud.githubusercontent.com/assets/2056489/4988184/d775e07a-6999-11e4-853a-72997ccbca6d.png
 
-5. Paste the webhook link form `bearychat` in Webhook field.
+5. Paste the webhook link form `bearychat`_ in Webhook field.
 
 .. image:: https://cloud.githubusercontent.com/assets/2056489/4988990/452d51e6-69ab-11e4-87f6-7cb3813ad309.png
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[wheel]
+[bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
 
 setup(
     name='sentry-bearychat',
-    version='0.2.0',
+    version='0.2.1',
     author='BearyInnovative',
     author_email='info@bearyinnovative.com',
     url='https://github.com/bearyinnovative/sentry-bearychat',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
 
 setup(
     name='sentry-bearychat',
-    version='0.2.2',
+    version='0.2.3',
     author='BearyInnovative',
     author_email='info@bearyinnovative.com',
     url='https://github.com/bearyinnovative/sentry-bearychat',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
 
 setup(
     name='sentry-bearychat',
-    version='0.2.1',
+    version='0.2.2',
     author='BearyInnovative',
     author_email='info@bearyinnovative.com',
     url='https://github.com/bearyinnovative/sentry-bearychat',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     author_email='info@bearyinnovative.com',
     url='https://github.com/bearyinnovative/sentry-bearychat',
     description='A Sentry extension which posts notifications to BearyChat (https://bearychat.com/).',
+    keywords='bearychat sentry',
     long_description=open('README.rst').read(),
     license='BSD',
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 sentry-bearychat
 ================
 
-An extension for `Sentry <https://getsentry.com>`_ which posts notifications to `Bearychat <https://bearychat.com>`_.
+An extension for `Sentry <https://getsentry.com>`_ which posts notifications to `BearyChat <https://bearychat.com>`_.
 
-:copyright: (c) 2014 by the BearyInnovative Team, see AUTHORS for more details.
+:copyright: (c) 2015 by the BearyInnovative Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
 from setuptools import setup, find_packages
@@ -17,11 +17,11 @@ install_requires = [
 
 setup(
     name='sentry-bearychat',
-    version='0.1.0',
+    version='0.2.0',
     author='BearyInnovative',
     author_email='info@bearyinnovative.com',
     url='https://github.com/bearyinnovative/sentry-bearychat',
-    description='A Sentry extension which posts notifications to Bearychat (https://bearychat.com/).',
+    description='A Sentry extension which posts notifications to BearyChat (https://bearychat.com/).',
     long_description=open('README.rst').read(),
     license='BSD',
     package_dir={'': 'src'},
@@ -34,7 +34,7 @@ setup(
             'bearychat = sentry_bearychat',
         ],
         'sentry.plugins': [
-            'bearychat = sentry_bearychat.plugin:BearychatPlugin',
+            'bearychat = sentry_bearychat.plugin:BearyChatPlugin',
         ]
     },
     classifiers=[

--- a/src/sentry_bearychat/plugin.py
+++ b/src/sentry_bearychat/plugin.py
@@ -37,9 +37,6 @@ class BearyChatPlugin(notify.NotificationPlugin):
     project_conf_form = BearyChatOptionsForm
     logger = logging.getLogger('sentry.plugins.bearychat')
 
-    def is_configured(self, project):
-        return bool(self.get_option('webhook', project))
-
     # use same data structure as Webhook plugin
     def get_group_data(self, group, event):
         data = {
@@ -65,7 +62,5 @@ class BearyChatPlugin(notify.NotificationPlugin):
         )
 
     def notify_users(self, group, event, fail_silently=False):
-        if not self.is_configured(project):
-            return
         payload = self.get_group_data(group, event)
         safe_execute(self.send_webhook, webhook, payload)

--- a/src/sentry_bearychat/plugin.py
+++ b/src/sentry_bearychat/plugin.py
@@ -56,6 +56,9 @@ class BearyChatPlugin(notify.NotificationPlugin):
         data['event']['tags'] = event.get_tags()
         return data
 
+    def get_webhook_url(self, project):
+        return self.get_option('webhook', project)
+
     def send_webhook(self, url, payload):
         return safe_urlopen(
             url=url,
@@ -65,7 +68,11 @@ class BearyChatPlugin(notify.NotificationPlugin):
         )
 
     def notify_users(self, group, event, fail_silently=False):
-        if not self.is_configured(group.project):
+        project = group.project
+
+        if not self.is_configured(project):
             return
+
+        url = self.get_webhook_url(project)
         payload = self.get_group_data(group, event)
-        safe_execute(self.send_webhook, webhook, payload)
+        safe_execute(self.send_webhook, url, payload)

--- a/src/sentry_bearychat/plugin.py
+++ b/src/sentry_bearychat/plugin.py
@@ -29,13 +29,13 @@ LEVEL_TO_COLOR = {
 }
 
 
-class BearychatOptionsForm(notify.NotificationConfigurationForm):
+class BearyChatOptionsForm(notify.NotificationConfigurationForm):
     webhook = forms.CharField(
-        help_text='Your custom Bearychat webhook URL',
+        help_text='Your custom BearyChat webhook URL',
         widget=forms.TextInput(attrs={'class': 'span8'}))
 
 
-class BearychatPlugin(notify.NotificationPlugin):
+class BearyChatPlugin(notify.NotificationPlugin):
     _repo_base = 'https://github.com/bearyinnovative/sentry-bearychat/'
     author = 'BearyInnovative Team'
     author_url = 'https://github.com/bearyinnovative/sentry-bearychat'
@@ -44,12 +44,12 @@ class BearychatPlugin(notify.NotificationPlugin):
         ('Bug Tracker', urljoin(_repo_base, 'issues')),
     )
 
-    title = 'Bearychat'
+    title = 'BearyChat'
     slug = 'bearychat'
-    description = 'Post new exceptions to a Bearychat channel.'
+    description = 'Post new exceptions to a BearyChat channel.'
     conf_key = 'bearychat'
     version = sentry_bearychat.VERSION
-    project_conf_form = BearychatOptionsForm
+    project_conf_form = BearyChatOptionsForm
 
     def is_configured(self, project):
         return all((self.get_option(k, project) for k in ('webhook',)))
@@ -104,9 +104,9 @@ class BearychatPlugin(notify.NotificationPlugin):
         try:
             return urllib2.urlopen(request).read()
         except urllib2.URLError:
-            logger.error('Could not connect to Bearychat.', exc_info=True)
+            logger.error('Could not connect to BearyChat.', exc_info=True)
             raise
         except urllib2.HTTPError as e:
-            logger.error('Error posting to Bearychat: %s',
+            logger.error('Error posting to BearyChat: %s',
                          e.read(), exc_info=True)
             raise

--- a/src/sentry_bearychat/plugin.py
+++ b/src/sentry_bearychat/plugin.py
@@ -37,6 +37,9 @@ class BearyChatPlugin(notify.NotificationPlugin):
     project_conf_form = BearyChatOptionsForm
     logger = logging.getLogger('sentry.plugins.bearychat')
 
+    def is_configured(self, project):
+        return bool(self.get_option('webhook', project))
+
     # use same data structure as Webhook plugin
     def get_group_data(self, group, event):
         data = {
@@ -62,5 +65,7 @@ class BearyChatPlugin(notify.NotificationPlugin):
         )
 
     def notify_users(self, group, event, fail_silently=False):
+        if not self.is_configured(group.project):
+            return
         payload = self.get_group_data(group, event)
         safe_execute(self.send_webhook, webhook, payload)


### PR DESCRIPTION
@xtang @shonenada 
参考 sentry 自己的 webhook plugin 而不是参考的 sentry 团队自己写的 slack incoming  的消息格式
https://github.com/getsentry/sentry/tree/master/src/sentry/plugins/sentry_webhooks
